### PR TITLE
Fix compatibility with Python 3.8+

### DIFF
--- a/src/transpyler/translate/translate.py
+++ b/src/transpyler/translate/translate.py
@@ -84,7 +84,7 @@ def apply_translations_function(func, data: dict):
     #
     code = func.__code__
     new_code = types.CodeType(
-        code.co_argcount, code.co_kwonlyargcount, code.co_nlocals,
+        code.co_argcount, code.co_posonlyargcount, code.co_kwonlyargcount, code.co_nlocals,
         code.co_stacksize, code.co_flags, code.co_code, code.co_consts,
         code.co_names, varnames, code.co_filename, code.co_name,
         code.co_firstlineno, code.co_lnotab, code.co_freevars,


### PR DESCRIPTION
[types.CodeType](https://docs.python.org/3/library/types.html#types.CodeType) has a new parameter in the second position of the constructor (posonlyargcount) to support positional-only arguments defined in [PEP 570](https://www.python.org/dev/peps/pep-0570).


This PR adds the new argument to the method call used in the apply_translations_function function.